### PR TITLE
Fix custom price range filter

### DIFF
--- a/src/components/pages/shopping-page/shopping-page.jsx
+++ b/src/components/pages/shopping-page/shopping-page.jsx
@@ -55,8 +55,8 @@ const ShoppingPage = (props) => {
     }
 
     function clearRange() {
-      refMin.current.value=0;
-      refMax.current.value=0;
+      refMin.current.value=null;
+      refMax.current.value=null;
       setPriceSubmit(false);
     }
 


### PR DESCRIPTION
The custom price range filter should be blank when not in use.
Previously, selecting a price range checkbox put 0's into the form
fields. Setting the ref to null makes it blank.

Fixes #1.