### PR TITLE
Add small screen layouts for shopping page

### DIFF
--- a/src/components/pages/shopping-page/product-card.css
+++ b/src/components/pages/shopping-page/product-card.css
@@ -1,41 +1,127 @@
+/* mobile-first */
 .product-card {
-  padding: 2%;
-  margin-left: 1rem 0;
-  height: fit-content;
+  display: flex;
+  flex-direction: row;
+  padding: 8px;
+  border-top: 1px solid lightgray;
 }
 
-.product-image img {
-  max-width: 100%;
+.card-image-wrapper img {
+  width: 130px;
+  max-height: 70%;
   cursor: pointer;
 }
 
-.product-info {
-  text-align: left;
-  margin-top: 20px;
+.card-info-wrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
 }
-.product-name {
+
+.card-title-size-wrapper {
+  text-align: left;
+}
+
+.product-title {
   font-size: 1.0em;
   font-weight: bold;
 }
 
 .product-size, .product-rating, .product-pickup, .product-delivery {
   font-size: 0.8em;
+  margin: 4px 0px;
 }
 
-.product-shipping {
-  font-size: 0.8em;
-  margin-bottom: 10px;
+.product-description {
+  display: none;
 }
-.green {
-  color: green;
+
+.card-pd-cart-wrapper {
+  min-width: 160px;
 }
 
 .product-price {
   margin-top: 10px;
-  margin-bottom: 20px; 
+  margin-bottom: 10px;
   font-size: 1.2em;
   font-weight: bold;
 }
+
+.product-shipping {
+  display: none;
+}
+
+.green {
+  color: green;
+}
+
+/* over 480px */
+
+@media screen and (min-width: 480px ) {
+
+  .card-info-wrapper {
+    flex-direction: row;
+  }
+
+  .card-title-size-wrapper {
+    padding-right: 16px;
+  }
+
+  .product-description {
+    display: block;
+    font-size: 0.7em;
+  }
+  
+  .card-pd-cart-wrapper {
+    margin-left: auto;
+  }
+}
+
+/* over 768 px */
+@media screen and (min-width: 768px ) {
+
+  .product-card {
+    flex-direction: column;
+    height: 424px;
+    padding: 8px;
+    margin-left: 1rem 0;
+    border: 1px solid lightgray;
+  }
+
+  .card-image-wrapper img {
+    width: auto;
+    max-width: 90%;
+    max-height: none;
+    padding-top: 20px;
+  }
+  
+  .card-info-wrapper {
+    margin-top: auto; /* push info to bottom for alignment */
+    flex-direction: column;
+  }
+
+  .card-title-size-wrapper {
+    padding-right: 0;
+  }
+
+  .product-description {
+    display: none;
+  }
+
+  .card-pd-cart-wrapper {
+    min-width: 0;
+    margin-left: 0;
+  }
+  
+}
+
+@media screen and (min-width: 1024px ) {
+.product-card {
+    height: 484px;
+    padding: 16px;
+  }
+}
+
 
 .add-cart-button {
   width: 100%;
@@ -45,6 +131,7 @@
   font-size: 0.8rem;
   font-weight: bold;
   cursor: pointer;
+  margin-top: 4px;
 }
 
 .add-cart-button:hover {

--- a/src/components/pages/shopping-page/product-card.jsx
+++ b/src/components/pages/shopping-page/product-card.jsx
@@ -39,27 +39,32 @@ const ProductCard = (props) => {
   return (
     <div className='product-card'>
 
-      {/* <div className='product-image' onClick={() => history.push(`/product/${product.id}`)}>
-        <img src={product.imageUrl}  alt='product' />         
-      </div> */}
-
-      <div className='product-image' onClick={() => history.push(`/product/${product.id}`)}>
+      <div className='card-image-wrapper' onClick={() => history.push(`/product/${product.id}`)}>
         <img src={bottleImage}  alt='product' />         
       </div>
 
-      <div className="product-info">
-        <div className="product-name">{product.title}</div>
-        <div className="product-size">{product.size}</div>
-        <div className="product-price">$ {product.price}</div>
-        <div className="product-pickup">Pick-up: <span className="green">{pickupDisplay}</span></div>
-        <div className="product-delivery">Local Delivery: <span className="green">{deliverDisplay}</span></div>
-        <div className="product-shipping">Shipping: <span className="green">{shipDisplay}</span></div>
+      <div className="card-info-wrapper">
 
-        { !itemInCart && <button className='add-cart-button' onClick={() => addProduct(product)}>Add to Cart</button> }
-        {  itemInCart && <button className='add-cart-button' onClick={()=> increase(product)}>Add More</button> }
+        <div className="card-title-size-wrapper">
+          <div className="product-title">{product.title}</div>
+          <div className="product-size">{product.size}</div>
+          <div className="product-description">{product.description}</div>
+        </div>
+
+        <div className="card-pd-cart-wrapper">
+          <div className="product-price">$ {product.price}</div>
+          <div className="product-pickup">Pick-up: <span className="green">{pickupDisplay}</span></div>
+          <div className="product-delivery">Delivery: <span className="green">{deliverDisplay}</span></div>
+          <div className="product-shipping">Shipping: <span className="green">{shipDisplay}</span></div>
+
+          { !itemInCart && <button className='add-cart-button' onClick={() => addProduct(product)}>Add to Cart</button> }
+          {  itemInCart && <button className='add-cart-button' onClick={()=> increase(product)}>Add More</button> }
+        </div>
       </div>
+
     </div>
   );
 }
 
 export default withRouter(ProductCard);
+

--- a/src/components/pages/shopping-page/shopping-page.css
+++ b/src/components/pages/shopping-page/shopping-page.css
@@ -5,16 +5,33 @@
 .shopping-title {
     font-size: 1.2em;
     font-weight: bold;
-    margin-left: 16px;
+    margin-left: 32px;
 }
 .shopping-page-container {
     display: flex;
     margin-top: 15px;
+    max-width: 1248px;
+    margin: 16px;
 }
 
 .filter-box {
-    min-width: 280px;
+    width: 248px;
+    flex-grow: 0;
+    flex-shrink: 0;
 }
+
+@media screen and (min-width: 1024px ) {
+  .filter-box {
+    width: 312px;
+  }
+}
+
+@media screen and (max-width: 767px ) {
+  .filter-box {
+    display: none;
+  }
+}
+  
 
 .filter-section {
     padding-left: 15px;
@@ -71,8 +88,14 @@ summary {
 }
 
 .product-grid {
-    display: inline-flex;
-    flex-wrap: wrap;
-    width: 100%;
+    display: grid;
+    grid-template-rows: 1fr;
+    grid-template-columns: 1fr;
+}
+
+@media screen and (min-width: 768px ) {
+    .product-grid {
+        grid-template-columns: repeat(3, 33fr);
+    }
 }
 


### PR DESCRIPTION
The shopping page now has breakpoints at 480, 768, and 1024. Screen
size < 768 has a single product, with formatting changing at 480.
Screen size > 768 has a 3 column grid, with the only change at 1024
being that the filter sidebar gets a little wider.