### PR TITLE
Add filter modal for small screens

### DIFF
--- a/src/components/pages/shopping-page/modal/modal.css
+++ b/src/components/pages/shopping-page/modal/modal.css
@@ -1,0 +1,49 @@
+.modal {
+  position: fixed;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  /* this makes the modal scrollable if it exceeds the screen height */
+  height: auto;
+  bottom: 0;
+  overflow: auto;
+  max-height: 100vh;
+}
+
+.modal-content {
+  width: 500px;
+  background-color: #fff;
+}
+
+
+.modal-header,
+.modal-footer {
+  padding: 10px;
+}
+
+.modal-title {
+  margin: 0;
+}
+
+.modal-body {
+  padding: 10px;
+  border-top: 1px solid #eee;
+  border-bottom: 1px solid #eee;
+}
+
+.modal-btn {
+  display: block;
+  margin: 0 auto;
+  width: 60%;
+  height: 2.5rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  background-color: black;
+  color: white;
+}

--- a/src/components/pages/shopping-page/modal/modal.jsx
+++ b/src/components/pages/shopping-page/modal/modal.jsx
@@ -1,0 +1,31 @@
+import "./modal.css";
+
+const Modal = props => {
+ 
+  if (!props.show) {
+    return null;
+  }
+
+  return (
+    <div className="modal" onClick={props.onClose}>
+      <div className="modal-content" onClick={e => e.stopPropagation()}>
+        <div className="modal-header">
+          <h4 className="modal-title">
+            {props.title}
+          </h4>
+        </div>
+        <button onClick={props.onClose} className="modal-btn">
+            {props.closeButtonText}
+        </button>
+        <div className="modal-body">
+          {props.children}
+        </div>
+        <div className="modal-footer">
+        </div>
+      </div>
+    </div>
+    )
+  };
+
+
+export default Modal;

--- a/src/components/pages/shopping-page/product-filter.jsx
+++ b/src/components/pages/shopping-page/product-filter.jsx
@@ -1,0 +1,144 @@
+import "./shopping-page.css";
+/*
+ * Filter component.
+*/
+
+const ProductFilter = ({values, handlers, broadResult}) => {
+     
+    // ========= use broad result to display region filters & counts ====================
+
+    // helper function
+    function generateCheckboxes(attribute) {
+      let array = [];
+      for (const elem of broadResult) {
+        const item = array.find(x => x.name === elem[attribute]);
+        if (!item)  
+          array.push({name: elem[attribute], count: 1});
+        else 
+          item.count++;
+      }
+      return array;
+    }
+  
+    // "checkboxes" is an array of objects of form {name: "bigregion", count: X}
+    let checkboxes = generateCheckboxes("bigregion");
+    const bigregionsToDisplay = [];  // array of JSX elements
+    for (const item of checkboxes) {
+      bigregionsToDisplay.push(<CheckboxWithCount  
+                                    label={item.name} 
+                                    name={item.name} 
+                                    value={values.bigregionActiveFilters.includes(item.name)} 
+                                    onChange={handlers.handleBigregionActiveFilters}
+                                    count={item.count} 
+                                    key={item.name} />);
+    }
+
+    // filter products by bigregion (eg, California) to decide which regions (eg, Napa, Sonoma) to display
+    if (values.bigregionActiveFilters.length > 0)
+      broadResult = broadResult.filter(prod => values.bigregionActiveFilters.includes(prod.bigregion));
+    
+    checkboxes = generateCheckboxes("region");
+    const regionsToDisplay = [];
+    for (const item of checkboxes) {
+        regionsToDisplay.push(<CheckboxWithCount  
+                                  label={item.name} 
+                                  name={item.name}
+                                  value={values.regionActiveFilters.includes(item.name)} 
+                                  onChange={handlers.handleRegionActiveFilters}
+                                  count={item.count} 
+                                  key={item.name} />);
+      }
+
+  return (
+    <div>
+
+      <div className="filter-section top2_filters">
+
+        <h3 className="filter-title">Shopping Method</h3>
+        <div>
+          <Checkbox label="Pickup at: (Local Store)" value={values.pickupLocal} onChange={handlers.handlePickupLocal} />
+          <Checkbox label="Pickup at: (All Stores)" value={values.pickupAll} onChange={handlers.handlePickupAll} />
+          <Checkbox label="Deliver to: (Zip)" value={values.deliver} onChange={handlers.handleDeliver} /> 
+          <Checkbox label="Ship to: (State)" value={values.shipTo} onChange={handlers.handleShipTo} />
+        </div>
+
+        <h3 className="filter-title">Product Availability</h3>
+        <div>
+          <Checkbox label="Include In-Store Purchases" value={values.inStoreOnly} onChange={handlers.handleInStoreOnly} />
+          <Checkbox label="Include Out of Stock Items" value={values.outOfStock} onChange={handlers.handleOutOfStock} />              
+        </div>
+    </div>  {/* top 2 filters */}
+
+    <div className="filter-section">
+      <h3 className="filter-title">Price Range</h3>
+      <div className="price-range-wrapper">
+        <form className="price-range-form">
+              <input className="price-input" value={values.priceMin} onChange={handlers.handlePriceMin}></input>
+              <span className="price-input-to">to</span>
+              <input className="price-input" value={values.priceMax} onChange={handlers.handlePriceMax}></input>
+        </form>
+      </div>
+
+      <div>
+        <Checkbox label="Up to $10" value={values.p0} onChange={handlers.handlePrice0to10} />
+        <Checkbox label="$10 to $20" value={values.p10} onChange={handlers.handlePrice10to20} />
+        <Checkbox label="$20 to $30" value={values.p20} onChange={handlers.handlePrice20to30} />
+        <Checkbox label="$30 to $50" value={values.p30} onChange={handlers.handlePrice30to50} />
+        <Checkbox label="Over $50" value={values.p50} onChange={handlers.handlePriceOver50} />
+      </div>
+
+      <details>
+        <summary>
+          Country / State
+        </summary>
+          {bigregionsToDisplay}
+      </details>
+
+      <details>
+        <summary>
+          Regions
+        </summary>
+          {regionsToDisplay}
+      </details>
+
+      <details>
+        <summary>
+          Size
+        </summary>
+        <Checkbox label="Standard 750 ml" value={values.size750} onChange={handlers.handleSize750} />
+        <Checkbox label="Half Bottle 375 ml" value={values.size375} onChange={handlers.handleSize375} />
+        <Checkbox label="Magnum 1.5 L" value={values.size1500} onChange={handlers.handleSize1500} />
+        <Checkbox label="Large Format 3+ L" value={values.size3000} onChange={handlers.handleSize3000} />
+      </details>
+    
+     </div>
+
+    </div>
+
+    )
+  };
+
+const Checkbox = ({ label, value, onChange }) => {
+  return (
+    <div>
+    <label className="lbl">
+      <input type="checkbox" checked={value} onChange={onChange} />
+      {label}
+    </label>
+    </div>
+  );
+};
+
+const CheckboxWithCount = ({ label, value, name, onChange, count }) => {
+  return (
+    <div>
+    <label className="lbl">
+      <input type="checkbox" checked={value} onChange={onChange} name={name} />
+      {label} ({count})
+    </label>
+    </div>
+  );
+};
+  
+
+export default ProductFilter;

--- a/src/components/pages/shopping-page/shopping-page.css
+++ b/src/components/pages/shopping-page/shopping-page.css
@@ -11,10 +11,32 @@
     font-weight: bold;
 }
 
-.shopping-title-results {
+.num-results {
     font-size: 1.0em;
     margin-top: 4px;
 }
+
+.num-results-modal {
+    font-size: 1.1em;
+    font-weight: bold;
+    margin-top: 4px;
+    margin-bottom: 8px;
+}
+
+.filter-btn {
+    --green-btn:  rgb(0, 127, 115);
+    background-color: white;
+    border-radius: 3px;  
+    border: 1px solid rgb(180, 186, 193);
+    color: var(--green-btn);  
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: bold;
+    height: 34px;
+    margin: 16px 0;
+    width: 80%;
+  }
+  
 
 .shopping-page-container {
     display: flex;
@@ -23,25 +45,40 @@
     margin: 16px;
 }
 
+
+/*====== Filter Stuff ====================== */
+/*  
+ * Screen size < 768:  a button that uses a modal to select the shopping filters.
+ * Screen size > 768:  a filter sidebar
+ *
+ *=========================================== */
+
 .filter-box {
-    width: 248px;
-    flex-grow: 0;
-    flex-shrink: 0;
-}
-
-@media screen and (min-width: 1024px ) {
-  .filter-box {
-    width: 312px;
-  }
-}
-
-@media screen and (max-width: 767px ) {
-  .filter-box {
     display: none;
-  }
 }
-  
 
+@media screen and (min-width: 768px ) {
+
+    .filter-btn-wrapper {
+        display: none;
+    }
+
+    .filter-box {
+      display: block;
+      width: 248px;
+      flex-grow: 0;
+      flex-shrink: 0;
+    }
+  }
+  
+@media screen and (min-width: 1024px ) {
+
+    .filter-box {
+        width: 312px;
+    }
+}
+
+  
 .filter-section {
     padding-left: 15px;
 }
@@ -49,7 +86,6 @@
 .filter-title {
     margin-bottom: 10px;
 }
-
 
 .top2_filters {
     background-color: whitesmoke;
@@ -95,6 +131,8 @@ summary {
     font-weight: bold;
     font-size: 1.2rem;
 }
+
+/*====== Product Grid ======*/
 
 .product-grid {
     display: grid;


### PR DESCRIPTION
On small screens, the shopping page now has a filter button which opens
a modal with the filtering options found in the sidebar on
larger screens.  The filter is refactored into a reusable component.
Finally, the custom price filter is now a controlled component that
reacts instantaneously, as opposed to a form that required clicking on
a submit button.

Fixes #7. 
