### PR TITLE
Set maximum width for cart page

### DIFF
--- a/src/components/pages/cart-page/cart-page.css
+++ b/src/components/pages/cart-page/cart-page.css
@@ -2,7 +2,8 @@
 .cp-container {
   display: flex;
   flex-direction: column;
-  margin-top: 20px;
+  max-width: 1200px;
+  margin: 20px auto;
 }
 
 .cp-section-title {


### PR DESCRIPTION
This prevents the cart page line items from stretching all the way across the page on a very wide screen, which looks awkward.